### PR TITLE
fix(core): use `Pxid` generator and rename to `register` over `create`

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -47,8 +47,8 @@ jobs:
         run: cargo run database migrate
 
       - name: Runs E2E tests
-        run: just e2e_test
-        
+        run: just e2e_tests
+
       - name: Stop containers
         if: always()
         run: docker compose down

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "pxid"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3386148396254a44a940ee72fa53615b9539169752b64a393f1dd1564838321a"
+checksum = "92572e83a97f5f573815b60c6ffec7c8b99285313f3434ea17add3422f64bfdb"
 dependencies = [
  "async-graphql",
  "crc32fast",

--- a/Justfile
+++ b/Justfile
@@ -24,7 +24,7 @@ serve:
   cargo run serve
 
 # Runs E2E Tests and optionally runs a specific test requires `e2e_test_dev` to be executed first.
-e2e_test *args='':
+e2e_tests *args='':
   cargo test --package test -- --test-threads=1 $1
 
 # Runs formatting tool against Leptos source

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ process.
 The dedicated E2E Database will be builded along with other containers when running `just dev`.
 
 You can also execute a single E2E Test by specifying the name of the test
-function along with the `just e2e_test` command:
+function along with the `just e2e_tests` command:
 
 ```bash
-just e2e_test my_super_test_function_name
+just e2e_tests my_super_test_function_name
 ```
 
 To run every test just execute:

--- a/crates/core/src/user/repository/user.rs
+++ b/crates/core/src/user/repository/user.rs
@@ -15,6 +15,9 @@ use crate::shared::query_set::QuerySet;
 use crate::user::error::{Result, UserError};
 use crate::user::model::{Email, User, Username};
 
+const UNIQUE_USERNAME_CONSTRAINT: &str = "user_username_key";
+const UNIQUE_EMAIL_CONSTRAINT: &str = "user_email_key";
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct UserFilter {
     pub id: Option<Pxid>,
@@ -118,11 +121,11 @@ impl UserRepository {
                 sea_orm::DbErr::Query(sea_orm::RuntimeErr::SqlxError(err)) => {
                     if let Some(db_err) = err.into_database_error() {
                         if let Some(constraint) = db_err.constraint() {
-                            if constraint == "user_username_key" {
+                            if constraint == UNIQUE_USERNAME_CONSTRAINT {
                                 return UserError::UsernameTakenError(dto.username);
                             }
 
-                            if constraint == "user_email_key" {
+                            if constraint == UNIQUE_EMAIL_CONSTRAINT {
                                 return UserError::EmailTakenError(dto.email);
                             }
                         }

--- a/crates/core/src/user/service.rs
+++ b/crates/core/src/user/service.rs
@@ -64,7 +64,7 @@ impl<P: ImageProvider> UserService<P> {
         }
     }
 
-    pub async fn create(&self, dto: CreateUserDto) -> Result<User> {
+    pub async fn register(&self, dto: CreateUserDto) -> Result<User> {
         self.repository
             .insert(InsertUserDto {
                 id: User::pxid()?.to_string(),

--- a/crates/server/src/graphql/modules/user/mutation/user_register.rs
+++ b/crates/server/src/graphql/modules/user/mutation/user_register.rs
@@ -38,7 +38,7 @@ impl UserRegister {
             password,
         };
 
-        match context.services.user.create(dto).await {
+        match context.services.user.register(dto).await {
             Ok(user) => Ok(Self {
                 user: Some(User::from(user)),
                 error: None,

--- a/crates/test/src/modules/post/post_create.rs
+++ b/crates/test/src/modules/post/post_create.rs
@@ -49,7 +49,7 @@ async fn create_post() {
     let user = context
         .services
         .user
-        .create(CreateUserDto {
+        .register(CreateUserDto {
             name: "John".to_string(),
             surname: "Appleseed".to_string(),
             username,
@@ -97,7 +97,7 @@ async fn creates_post_with_parent() {
     let user = context
         .services
         .user
-        .create(CreateUserDto {
+        .register(CreateUserDto {
             name: "John".to_string(),
             surname: "Appleseed".to_string(),
             username,

--- a/crates/test/src/modules/user/user_update.rs
+++ b/crates/test/src/modules/user/user_update.rs
@@ -16,7 +16,7 @@ async fn updates_a_user() {
     let user = context
         .services
         .user
-        .create(CreateUserDto {
+        .register(CreateUserDto {
             name: "Augustine".into(),
             surname: "Madu".into(),
             email: Email::from_str("augustine@gmail.com").unwrap(),


### PR DESCRIPTION
Fixes tests where using [Pxid generator causes repeated IDs on resource creation](https://github.com/whizzes/pxid/pull/20).

As well updates naming on UserService to represent Registration over user creation.